### PR TITLE
Ensure connections are cleaned up

### DIFF
--- a/a2s/a2s_async.py
+++ b/a2s/a2s_async.py
@@ -19,9 +19,11 @@ logger = logging.getLogger("a2s")
 
 async def request_async(address, timeout, encoding, a2s_proto):
     conn = await A2SStreamAsync.create(address, timeout)
-    response = await request_async_impl(conn, encoding, a2s_proto)
-    conn.close()
-    return response
+    try:
+        response = await request_async_impl(conn, encoding, a2s_proto)
+        return response
+    finally:
+        conn.close()
 
 async def request_async_impl(conn, encoding, a2s_proto, challenge=0, retries=0, ping=None):
     send_time = time.monotonic()

--- a/a2s/a2s_sync.py
+++ b/a2s/a2s_sync.py
@@ -19,9 +19,11 @@ logger = logging.getLogger("a2s")
 
 def request_sync(address, timeout, encoding, a2s_proto):
     conn = A2SStream(address, timeout)
-    response = request_sync_impl(conn, encoding, a2s_proto)
-    conn.close()
-    return response
+    try:
+        response = request_sync_impl(conn, encoding, a2s_proto)
+        return response
+    finally:
+        conn.close()
 
 def request_sync_impl(conn, encoding, a2s_proto, challenge=0, retries=0, ping=None):
     send_time = time.monotonic()


### PR DESCRIPTION
Fix exceptions caused when the garbage collector tries to close an A2SStreamAysnc object after the asyncio event loop closes by closing the A2SStreamAysnc object in `request_async()` even after an exception is thrown in `request_async_impl()`.
I employed the fix in a2s_sync.py for the sake of consistency even though there is no asyncio event loop in such cases. If anything, I would guess the connection will be closed sooner when an exception is thrown instead of later during garbage collection.

Example exception this fix is targeting:
```
Exception ignored in: <function A2SStreamAsync.__del__ at 0x7fc4953f4180>
Traceback (most recent call last):
  File "/project_root/.venv/lib/python3.13/site-packages/a2s/a2s_async.py", line 105, in __del__
    self.close()
  File "/project_root/.venv/lib/python3.13/site-packages/a2s/a2s_async.py", line 138, in close
    self.transport.close()
  File "/home/jacob/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/asyncio/selector_events.py", line 869, in close
    self._loop.call_soon(self._call_connection_lost, None)
  File "/home/jacob/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/asyncio/base_events.py", line 833, in call_soon
    self._check_closed()
  File "/home/jacob/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/asyncio/base_events.py", line 556, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```